### PR TITLE
Manually added default axis_shift to grid spec yaml

### DIFF
--- a/cmip6_preprocessing/specs/staggered_grid_config.yaml
+++ b/cmip6_preprocessing/specs/staggered_grid_config.yaml
@@ -332,3 +332,10 @@ UKESM1-0-LL:
     axis_shift:
       X: right
       Y: right
+# This is manually added (due to missing velocity data in the cloud). Might have to adjust if it causes issues.
+MPI-ESM1-2-LR:
+  gn:
+    axis_shift:
+      X: left
+      Y: left
+      


### PR DESCRIPTION
This model did not have velocity data in the cloud storage. In order to work with tracer data only I am adding these default values (both shifted left) to the yaml.