### PR TITLE
Add ni and nj as dimensions to be corrected

### DIFF
--- a/cmip6_preprocessing/preprocessing.py
+++ b/cmip6_preprocessing/preprocessing.py
@@ -10,7 +10,7 @@ def cmip6_renaming_dict():
     and valuse are a dict of target name (key) and a list of variables that
     should be renamed into the target."""
     rename_dict = {
-        # dim labels
+        # dim labels (order represents the priority when checking for the dim labels)
         "x": ["x", "i", "ni", "nlon", "lon", "longitude"],
         "y": ["y", "j", "nj", "nlat", "lat", "latitude"],
         "lev": ["lev", "deptht", "olevel", "zlev", "olev"],

--- a/cmip6_preprocessing/preprocessing.py
+++ b/cmip6_preprocessing/preprocessing.py
@@ -11,8 +11,8 @@ def cmip6_renaming_dict():
     should be renamed into the target."""
     rename_dict = {
         # dim labels
-        "x": ["x", "i", "nlon", "lon", "longitude"],
-        "y": ["y", "j", "nlat", "lat", "latitude"],
+        "x": ["x", "i", "ni", "nlon", "lon", "longitude"],
+        "y": ["y", "j", "nj", "nlat", "lat", "latitude"],
         "lev": ["lev", "deptht", "olevel", "zlev", "olev"],
         "bnds": ["bnds", "axis_nbounds", "d2"],
         "vertex": ["vertex", "nvertex", "vertices"],

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,6 +34,9 @@ Documentation
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
+-  Add `ni` and `nj` to the `rename_dict` dictionary in _preprocessing.py_ as dimensions to be corrected (:pull:`54`)
+   By `Markus Ritschel <https://github.com/markusritschel>`_
+   
 
 .. _whats-new.0.1.2:
 


### PR DESCRIPTION
As a remark:
Sometimes, `lon` and `lat` are 2D coordinates depending on `ni` and `nj`, respectively. For example,
```
<xarray.Dataset>
Dimensions:    (bnds: 2, ni: 320, nj: 384, nvertices: 4, time: 1980)
Coordinates:
  * time       (time) object 1850-01-15 12:00:00 ... 2014-12-15 12:00:00
    lon        (nj, ni) float64 ...
    lat        (nj, ni) float64 ...
  * ni         (ni) int32 1 2 3 4 5 6 7 8 9 ... 313 314 315 316 317 318 319 320
  * nj         (nj) int32 1 2 3 4 5 6 7 8 9 ... 377 378 379 380 381 382 383 384
. . .
```
I added the entries for `ni` and `nj` in the `rename_dict` pretty much in the front of the list since, otherwise, it could lead to unwanted behavior.
The current routine checks only for the first appearance of the key in that list. If `ni` was placed at the end of the list, the routine would stop at `lon` (setting the `trigger=True` and would not even check for `ni`. In the above example, this would rename the 2D coordinate `lon (nj, ni)` to `x (ni, nj)`.
The desired behavior, however, is:
```
    lon        (y, x) float64 ...
    lat        (y, x) float64 ...
  * x          (x) int32 1 2 3 4 5 6 7 8 9 ... 313 314 315 316 317 318 319 320
  * y          (y) int32 1 2 3 4 5 6 7 8 9 ... 377 378 379 380 381 382 383 384
```
So, one must really keep the order in mind.
Maybe this should be considered when revising the routine at some point.