### PR TITLE
Added `depth` to renaming convention

### DIFF
--- a/cmip6_preprocessing/preprocessing.py
+++ b/cmip6_preprocessing/preprocessing.py
@@ -13,7 +13,7 @@ def cmip6_renaming_dict():
         # dim labels (order represents the priority when checking for the dim labels)
         "x": ["x", "i", "ni", "xh", "nlon", "lon", "longitude"],
         "y": ["y", "j", "nj", "yh", "nlat", "lat", "latitude"],
-        "lev": ["lev", "deptht", "olevel", "zlev", "olev"],
+        "lev": ["lev", "deptht", "olevel", "zlev", "olev", "depth"],
         "bnds": ["bnds", "axis_nbounds", "d2"],
         "vertex": ["vertex", "nvertex", "vertices"],
         # coordinate labels


### PR DESCRIPTION
I just encountered a file like this:

```
<xarray.Dataset>
Dimensions:      (bnds: 2, time: 1980, vertex: 4, x: 362, y: 332)
Coordinates:
    lat          (y, x) float32 dask.array<chunksize=(332, 362), meta=np.ndarray>
    lat_bounds   (y, x, vertex) float32 dask.array<chunksize=(332, 362, 4), meta=np.ndarray>
    lon          (y, x) float32 dask.array<chunksize=(332, 362), meta=np.ndarray>
    lon_bounds   (y, x, vertex) float32 dask.array<chunksize=(332, 362, 4), meta=np.ndarray>
  * time         (time) int64 0 708 1416 2148 ... 1444152 1444884 1445616
    time_bounds  (time, bnds) float64 dask.array<chunksize=(3, 1), meta=np.ndarray>
Dimensions without coordinates: bnds, vertex, x, y
Data variables:
    area         (y, x) float32 dask.array<chunksize=(332, 362), meta=np.ndarray>
    depth        float64 ...
    epc100       (time, y, x) float32 dask.array<chunksize=(3, 332, 362), meta=np.ndarray>
Attributes:
    CMIP6_CV_version:       cv=6.2.3.5-2-g63b123e
    Conventions:            CF-1.7 CMIP-6.2
    EXPID:                  historical
    activity_id:            CMIP
    branch_method:          standard
    branch_time_in_child:   [0.0]
    branch_time_in_parent:  [7305.0]
    contact:                ipsl-cmip6@listes.ipsl.fr
    creation_date:          2018-05-11T14:33:56Z
    data_specs_version:     01.00.21
    description:            CMIP6 historical
    dr2xml_md5sum:          00e1a4f623b35a33620b9828c66bd1c8
    dr2xml_version:         1.3
    experiment:             all-forcing simulation of the recent past
    experiment_id:          historical
    external_variables:     areacello
    forcing_index:          [1]
    frequency:              mon
    further_info_url:       https://furtherinfo.es-doc.org/CMIP6.IPSL.IPSL-CM...
    grid:                   native ocean tri-polar grid with 105 k ocean cells
    grid_label:             gn
    history:                Mon Sep  3 14:29:59 2018: ncatted -O -a parent_va...
    initialization_index:   [1]
    institution:            Institut Pierre Simon Laplace, Paris 75252, France
    institution_id:         IPSL
    license:                CMIP6 model data produced by IPSL is licensed und...
    mip_era:                CMIP6
    model_version:          6.1.2
    name:                   /ccc/work/cont003/gencmip6/lurtont/IGCM_OUT/IPSLC...
    nominal_resolution:     100 km
    parent_activity_id:     CMIP
    parent_experiment_id:   piControl
    parent_mip_era:         CMIP6
    parent_source_id:       IPSL-CM6A-LR
    parent_time_units:      days since 1850-01-01 00:00:00
    parent_variant_label:   r1i1p1f1
    physics_index:          [1]
    product:                model-output
    realization_index:      [2]
    realm:                  ocnBgchem
    source:                 IPSL-CM6A-LR (2017):  atmos: LMDZ (NPv6, N96; 144...
    source_id:              IPSL-CM6A-LR
    source_type:            AOGCM
    sub_experiment:         none
    sub_experiment_id:      none
    table_id:               Omon
    title:                  IPSL-CM6A-LR model output prepared for CMIP6 / CM...
    tracking_id:            hdl:21.14100/8062e9dc-3f4f-4f9f-86f4-afe580a421bc
    variable_id:            epc100
    variant_info:           Restart from another point in piControl.. Informa...
    variant_label:          r2i1p1f1
    intake_esm_varname:     epc100
```

The `depth` is incorrectly declared as data_variable. I think adding `depth` to the renaming list, will fix this. 

I should however make a test with this data.