### PR TITLE
Fix nan values in nominal x/y coordinates

### DIFF
--- a/cmip6_preprocessing/preprocessing.py
+++ b/cmip6_preprocessing/preprocessing.py
@@ -141,22 +141,25 @@ def replace_x_y_nominal_lat_lon(ds):
             return data
 
     if "x" in ds.dims and "y" in ds.dims:
+        # define 'nominal' longitude/latitude values
+        # latitude is defined as the max value of `lat` in the zonal direction
+        # longitude is taken from the `middle` of the meridonal direction, to
+        # get values close to the equator
 
         # pick the nominal lon/lat values from the eastern
-        # and southern edge, and eliminate non unique values
-        # these occour e.g. in "MPI-ESM1-2-HR"
-        max_lat_idx = ds.lat.isel(y=-1).argmax("x").load().data
+        # and southern edge, and
         eq_idx = len(ds.y) // 2
 
         nominal_x = ds.isel(y=eq_idx).lon.load()
-        nominal_y = ds.isel(x=max_lat_idx).lat.load()
+        nominal_y = ds.lat.max("x").load()
 
         # interpolate nans
         # Special treatment for gaps in longitude
         nominal_x = _interp_nominal_lon(nominal_x.data)
         nominal_y = nominal_y.interpolate_na("y").data
 
-        # remove dupes
+        # eliminate non unique values
+        # these occour e.g. in "MPI-ESM1-2-HR"
         nominal_y = maybe_fix_non_unique(nominal_y)
         nominal_x = maybe_fix_non_unique(nominal_x)
 

--- a/cmip6_preprocessing/preprocessing.py
+++ b/cmip6_preprocessing/preprocessing.py
@@ -230,8 +230,8 @@ def correct_lon(ds):
 
     # remove out of bounds values found in some
     # models as missing values
-    ds["lon"] = ds["lon"].where(abs(ds["lon"]) <= 1e35)
-    ds["lat"] = ds["lat"].where(abs(ds["lat"]) <= 1e35)
+    ds["lon"] = ds["lon"].where(abs(ds["lon"]) <= 1000)
+    ds["lat"] = ds["lat"].where(abs(ds["lat"]) <= 1000)
 
     # adjust lon convention
     lon = ds["lon"].where(ds["lon"] > 0, 360 + ds["lon"])

--- a/cmip6_preprocessing/tests/test_preprocessing.py
+++ b/cmip6_preprocessing/tests/test_preprocessing.py
@@ -244,7 +244,7 @@ def test_parse_lon_lat_bounds():
         -360,
     ],
 )  # cant handle positive shifts yet
-def test_correct_lon(missing_values, shift, nans):
+def test_correct_lon(missing_values, shift):
     xlen, ylen, zlen = (40, 20, 6)
     ds = create_test_ds("x", "y", "lev", xlen, ylen, zlen)
     ds = ds.assign_coords(x=ds.x.data + shift)

--- a/cmip6_preprocessing/tests/test_preprocessing_cloud.py
+++ b/cmip6_preprocessing/tests/test_preprocessing_cloud.py
@@ -13,8 +13,8 @@ from cmip6_preprocessing.grids import combine_staggered_grid
 
 pytest.importorskip("gcsfs")
 
-test_models = ["CESM2-FV2", "GFDL-CM4"]
-# test_models = all_models()
+# test_models = ["CESM2-FV2", "GFDL-CM4"]
+test_models = all_models()
 
 
 def pytest_generate_tests(metafunc):
@@ -191,7 +191,6 @@ def spec_check_bounds_verticies(request, gl, vi, ei):
         ("AWI-ESM-1-1-MR", "thetao", "ssp585", "gn"),
         ("AWI-CM-1-1-MR", "thetao", "historical", "gn"),
         ("AWI-CM-1-1-MR", "thetao", "ssp585", "gn"),
-        ("CESM2-FV2", "thetao", "historical", "gn"),
         ("FGOALS-f3-L", "thetao", "historical", "gn"),
         ("FGOALS-f3-L", "thetao", "ssp585", "gn"),
         ("FGOALS-g3", "thetao", "historical", "gn"),
@@ -281,7 +280,6 @@ def spec_check_grid(request, gl, vi, ei):
         ("AWI-ESM-1-1-MR", "thetao", "ssp585", "gn"),
         ("AWI-CM-1-1-MR", "thetao", "historical", "gn"),
         ("AWI-CM-1-1-MR", "thetao", "ssp585", "gn"),
-        ("CESM2-FV2", "thetao", "historical", "gn"),
         ("CMCC-CM2-SR5", "thetao", "historical", "gn"),
         ("CMCC-CM2-SR5", "thetao", "ssp585", "gn"),
         ("FGOALS-f3-L", "thetao", "historical", "gn"),

--- a/cmip6_preprocessing/tests/test_preprocessing_cloud.py
+++ b/cmip6_preprocessing/tests/test_preprocessing_cloud.py
@@ -13,8 +13,8 @@ from cmip6_preprocessing.grids import combine_staggered_grid
 
 pytest.importorskip("gcsfs")
 
-# test_models = ["CESM2-FV", "GFDL-ESM4", "GFDL-CM4", "CanESM5"]
-test_models = all_models()
+test_models = ["CESM2-FV2", "GFDL-CM4"]
+# test_models = all_models()
 
 
 def pytest_generate_tests(metafunc):
@@ -47,7 +47,6 @@ def spec_check_dim_coord_values_wo_intake(request, gl, vi, ei):
         ("AWI-CM-1-1-MR", "thetao", "historical", "gn"),
         ("AWI-CM-1-1-MR", "thetao", "ssp585", "gn"),
         # TODO: would be nice to have a "*" matching...
-        ("CESM2-FV2", "thetao", "historical", "gn"),
         # (
         #     "GFDL-CM4",
         #     "thetao",
@@ -55,7 +54,6 @@ def spec_check_dim_coord_values_wo_intake(request, gl, vi, ei):
         #     "gn",
         # ),  # this should not fail and should trigger an xpass (I just use this for dev purposes to check
         #     # the strict option)
-        ("CESM2-FV2", "thetao", "ssp585", "gn"),
     ]
     spec = (request.param, vi, ei, gl)
     request.param = spec
@@ -96,7 +94,7 @@ def test_check_dim_coord_values_wo_intake(
             diagnose_doubles(ds[di].load().data)
             assert len(ds[di]) == len(np.unique(ds[di]))
             if di != "time":  # these tests do not make sense for decoded time
-                assert ~np.all(np.isnan(ds[di]))
+                assert np.all(~np.isnan(ds[di]))
                 assert np.all(ds[di].diff(di) >= 0)
 
     assert ds.lon.min().load() >= 0
@@ -108,6 +106,7 @@ def test_check_dim_coord_values_wo_intake(
     assert ds.lat.max().load() <= 90
     # make sure lon and lat are 2d
     assert len(ds.lon.shape) == 2
+    assert len(ds.lat.shape) == 2
 
 
 # this fixture has to be redifined every time to account for different fail cases for each test
@@ -119,8 +118,6 @@ def spec_check_dim_coord_values(request, gl, vi, ei):
         ("AWI-CM-1-1-MR", "thetao", "historical", "gn"),
         ("AWI-CM-1-1-MR", "thetao", "ssp585", "gn"),
         # TODO: would be nice to have a "*" matching...
-        ("CESM2-FV2", "thetao", "historical", "gn"),
-        ("CESM2-FV2", "thetao", "ssp585", "gn"),
         (
             "IPSL-CM6A-LR",
             "thetao",
@@ -167,7 +164,7 @@ def test_check_dim_coord_values(
             diagnose_doubles(ds[di].load().data)
             assert len(ds[di]) == len(np.unique(ds[di]))
             if di != "time":  # these tests do not make sense for decoded time
-                assert ~np.all(np.isnan(ds[di]))
+                assert np.all(~np.isnan(ds[di]))
                 assert np.all(ds[di].diff(di) >= 0)
 
     assert ds.lon.min().load() >= 0

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -10,6 +10,9 @@ v0.2.0 (unreleased)
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
+- Further refactor of `replace_x_y_nominal_lat_lon`, which avoids missing values in the dimension coordinates (:issue:`66`) (:pull:`79`)
+By `Julius Busecke <https://github.com/jbusecke>`_
+
 - Consistent treatment of cf-style bounds. The combination of `parse_lon_lat_bounds`,
 `maybe_convert_bounds_to_vertex`, `maybe_convert_vertex_to_bounds`, and `sort_vertex_order` applied on the dataset, assures
 that all datasets have both conventions available and the vertex order is the same.


### PR DESCRIPTION
- [x] Closes #66

I think I have identified the problem for #66, which is that missing values in `lon` are removed and then seem to produce nans in the dimension coordinates, which trips up xarray.

Not exactly sure if I should compute the lons as the average/median along y? That would however change the values...
If #75 is not successful, we might consider removing this step all together instead. 