### PR TITLE
Remove testing cat from ci

### DIFF
--- a/.github/workflows/full_archive_ci.yaml
+++ b/.github/workflows/full_archive_ci.yaml
@@ -17,7 +17,7 @@ jobs:
         experiment_id: ['historical','piControl', 'esm-hist', 'esm-piControl',
         'ssp245', 'ssp370','ssp585', 'ssp119']
         grid_label: ['gn', 'gr']
-        catalog: ['main', 'testing']
+        catalog: ['main']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/cmip6_preprocessing/utils.py
+++ b/cmip6_preprocessing/utils.py
@@ -15,10 +15,10 @@ def google_cmip_col(catalog="main"):
             "https://storage.googleapis.com/cmip6/pangeo-cmip6.json"
         )
     # this doesnt work anymore, but ill leave it here as an example for the future
-#     elif catalog == "testing":
-#         return intake.open_esm_datastore(
-#             "https://storage.googleapis.com/cmip6/pangeo-cmip6-testing.json"
-#         )
+    #     elif catalog == "testing":
+    #         return intake.open_esm_datastore(
+    #             "https://storage.googleapis.com/cmip6/pangeo-cmip6-testing.json"
+    #         )
     else:
         raise ValueError("Catalog not recognized. Should be `main` or `testing`")
 

--- a/cmip6_preprocessing/utils.py
+++ b/cmip6_preprocessing/utils.py
@@ -14,10 +14,11 @@ def google_cmip_col(catalog="main"):
         return intake.open_esm_datastore(
             "https://storage.googleapis.com/cmip6/pangeo-cmip6.json"
         )
-    elif catalog == "testing":
-        return intake.open_esm_datastore(
-            "https://storage.googleapis.com/cmip6/pangeo-cmip6-testing.json"
-        )
+    # this doesnt work anymore, but ill leave it here as an example for the future
+#     elif catalog == "testing":
+#         return intake.open_esm_datastore(
+#             "https://storage.googleapis.com/cmip6/pangeo-cmip6-testing.json"
+#         )
     else:
         raise ValueError("Catalog not recognized. Should be `main` or `testing`")
 

--- a/tests/test_preprocessing_cloud.py
+++ b/tests/test_preprocessing_cloud.py
@@ -413,7 +413,7 @@ def spec_check_grid(request, gl, vi, ei, cat):
         not_supported_failures
         + intake_concat_failures
         + [
-            ("CMCC-ESM2", "zos", "historical", "gn"),
+            ("CMCC-ESM2", "*", "*", "gn"),
             ("CMCC-CM2-SR5", "*", "*", "gn"),
             ("CMCC-CM2-HR4", "*", "*", "gn"),
             ("FGOALS-f3-L", "*", "*", "gn"),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,11 +9,6 @@ pytest.importorskip("intake")
 def test_google_cmip_col():
     col = google_cmip_col(catalog="main")
     assert col.catalog_file == "https://storage.googleapis.com/cmip6/pangeo-cmip6.csv"
-    col = google_cmip_col(catalog="testing")
-    assert (
-        col.catalog_file
-        == "https://storage.googleapis.com/cmip6/pangeo-cmip6-testing.csv"
-    )
 
 
 def test_model_id_match():


### PR DESCRIPTION
The testing catalog is no longer available. This PR removes it from the CI. The mechanism to test multiple catalogs should stay intact for later.