### PR TITLE
Improve error handling parse metrics

### DIFF
--- a/cmip6_preprocessing/utils.py
+++ b/cmip6_preprocessing/utils.py
@@ -53,3 +53,33 @@ def model_id_match(match_list, id_tuple):
                 ml_processed.append(False)
         match_list_checked.append(all(ml_processed))
     return any(match_list_checked)
+
+
+def cmip6_dataset_id(
+    ds,
+    sep=".",
+    id_attrs=[
+        "activity_id",
+        "institution_id",
+        "source_id",
+        "experiment_id",
+        "table_id",
+        "grid_label",
+        "version",
+    ],
+):
+    """Creates a unique string id for e.g. saving files to disk from CMIP6 output
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Input dataset
+    sep : str, optional
+        String/Symbol to seperate fields in resulting string, by default "."
+
+    Returns
+    -------
+    str
+        Concatenated
+    """
+    return sep.join([ds.attrs[i] if i in ds.attrs.keys() else "none" for i in id_attrs])

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -5,11 +5,13 @@ import xarray as xr
 from cmip6_preprocessing.postprocessing import match_metrics, parse_metric
 
 
-def random_ds():
+def random_ds(time_coords=False):
     """Create random dataset"""
     nx, ny, nz, nt = (3, 2, 4, 6)
     data = np.random.rand(nx, ny, nz, nt)
     da = xr.DataArray(data, dims=["x", "y", "z", "time"])
+    if time_coords:
+        da = da.assign_coords(time=xr.cftime_range("2000", periods=nt))
     return da.to_dataset(name="data")
 
 
@@ -66,7 +68,7 @@ def test_parse_metric_exceptions_input_name():
     )
 
 
-def test_parse_metric_exception_dim_alignment():
+def test_parse_metric_exception_dim_length():
     metricname = "metric"
     # create a dataset
     ds = random_ds()
@@ -80,36 +82,33 @@ def test_parse_metric_exception_dim_alignment():
         ds_parsed = parse_metric(
             ds, ds_metric.isel(x=slice(0, -1), y=slice(1, None))[metricname]
         )
-    msg = "a.none.none.none.none.g.none:`metric` dimensions ['x:2', 'y:1'] do not match `ds` ['x:3', 'y:2']"
+    msg = "a.none.none.none.none.g.none:`metric` dimensions ['x:2', 'y:1'] do not match `ds` ['x:3', 'y:2']."
     assert execinfo.value.args[0] == msg
 
 
-# @pytest.mark.parametrize("metricname", ["metric", "something"])
-# def test_parse_metric_exception_different_dim_length(metricname):
-#     # create a dataset
-#     ds = random_ds()
-#     # create a metric dataset that has one less time value than the dataset.
-#     ds_metric = random_ds().isel(z=0, time=slice(0,-1)).rename({"data": metricname})
+def test_parse_metric_dim_alignment():
+    metricname = "metric"
+    # create a dataset
+    ds = random_ds(time_coords=True)
+    # create a metric dataset
+    ds_metric = (
+        random_ds(time_coords=True)
+        .isel(z=0, time=slice(0, -1))
+        .rename({"data": metricname})
+    )
+    # set attributes
+    ds.attrs = {"activity_id": "a", "grid_label": "g"}
 
-#     # parse exactly the same attrs
-#     attrs =
+    print(ds)
 
-#     # provide dataset instead of dataarray
-#     with pytest.raises(ValueError):
-#         ds_parsed = parse_metric(ds, ds_metric)
+    # Allow alignment
+    with pytest.warns(UserWarning) as warninfo:
+        ds_parsed = parse_metric(ds, ds_metric[metricname], dim_length_conflict="align")
 
-#     # provide dataarray without name
-#     with pytest.warns(RuntimeWarning):
-#         da_metric_nameless = ds_metric[metricname]
-#         da_metric_nameless.name = None
+    xr.testing.assert_allclose(ds_parsed.time, ds_metric.time)
 
-#         ds_parsed = parse_metric(ds, da_metric_nameless)
-
-#     # provide dataarray with non-matching dimensions
-#     with pytest.raises(ValueError):
-#         ds_parsed = parse_metric(
-#             ds, ds_metric.isel(x=slice(0, -1), y=slice(1, None))[metricname]
-#         )
+    msg = "a.none.none.none.none.g.none:`metric` dimensions ['time:5'] do not match `ds` ['time:6']. Aligning the data on `inner`"
+    assert warninfo[0].message.args[0] == msg
 
 
 def test_match_metrics():
@@ -282,6 +281,36 @@ def test_match_metrics_exceptions():
     ds_metric.attrs = attrs
     with pytest.raises(ValueError):
         match_metrics({"a": ds}, {"aa": ds_metric}, [metricname])
+
+
+def test_match_metrics_align_dims():
+    metricname = "metric"
+    attrs = {
+        "source_id": "a",
+        "grid_label": "a",
+        "experiment_id": "a",
+        "table_id": "a",
+        "variant_label": "a",
+        "version": "a",
+    }
+    ds = random_ds(time_coords=True)
+    ds.attrs = attrs
+    ds_metric = (
+        random_ds(time_coords=True).isel(time=slice(0, -1)).rename({"data": metricname})
+    )
+    ds_metric.attrs = attrs
+    with pytest.warns(UserWarning) as warninfo:
+        ddict_matched = match_metrics(
+            {"a": ds},
+            {"aa": ds_metric},
+            [metricname],
+            print_statistics=True,
+            dim_length_conflict="align",
+        )
+    msg = "none.none.a.a.a.a.a:`metric` dimensions ['time:5'] do not match `ds` ['time:6']. Aligning the data on `inner`"
+    assert warninfo[0].message.args[0] == msg
+
+    xr.testing.assert_allclose(ddict_matched["a"].time, ds_metric.time)
 
 
 def test_match_metrics_print_statistics(capsys):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
+import xarray as xr
 
-from cmip6_preprocessing.utils import google_cmip_col, model_id_match
+from cmip6_preprocessing.utils import cmip6_dataset_id, google_cmip_col, model_id_match
 
 
 def test_google_cmip_col():
@@ -46,4 +47,24 @@ def test_model_id_match():
     assert model_id_match([(["bb", "b"], "a", "aa")], ("b", "a", "aa"))
     assert model_id_match(
         [(["bb", "b"], "a", "aa"), (["bb", "b"], "c", "cc")], ("bb", "a", "aa")
+    )
+
+
+def test_cmip6_dataset_id():
+    ds = xr.Dataset({"data": 4})
+
+    ds.attrs = {
+        "activity_id": "ai",
+        "institution_id": "ii",
+        "source_id": "si",
+        "experiment_id": "ei",
+        "table_id": "ti",
+        "grid_label": "gl",
+    }
+
+    assert cmip6_dataset_id(ds) == "ai.ii.si.ei.ti.gl.none"
+    assert cmip6_dataset_id(ds, sep="_") == "ai_ii_si_ei_ti_gl_none"
+    assert (
+        cmip6_dataset_id(ds, id_attrs=["grid_label", "activity_id", "wrong_attrs"])
+        == "gl.ai.none"
     )


### PR DESCRIPTION
I ran into some issues for datasets, where the thickness metric does not have the same amount of time steps as the data. 

This PR implements:

- [x] Some options to still join these coordinates with `join='inner'`
- [x] More informative errors, which identify the dataset in question.
- [ ]  Entry to `whats-new.rst`
- [ ]  Example in the docs