### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ install_requires =
     xgcm
     cftime
     cartopy
+    cython
 setup_requires=
     setuptools_scm
 python_requires = >=3.6


### PR DESCRIPTION
The new release CI errors out while installing cartopy (https://github.com/jbusecke/cmip6_preprocessing/runs/2750706353?check_suite_focus=true#step:7:333). Lets see If I can fix that. 