### PR TITLE
Prune dependencies

### DIFF
--- a/ci/environment-cloud-test.yml
+++ b/ci/environment-cloud-test.yml
@@ -8,8 +8,6 @@ dependencies:
   - xgcm
   - cftime
   - regionmask
-  - pyproj
-  - matplotlib
   # Dependencies for the pangeo cloud data
   - intake-esm
   - gcsfs

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -5,7 +5,6 @@ dependencies:
   - python=3.8
   - pyproj
   - matplotlib
-  - cartopy
   - cftime
   - dask
   - pip

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -2,10 +2,10 @@ name: test_env_cmip6_preprocessing
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
   - cftime
   - dask
   - pip
+  - cartopy
   - pip:
     - codecov
     - pytest-cov

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -3,8 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8
-  - pyproj
-  - matplotlib
   - cftime
   - dask
   - pip

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -4,9 +4,7 @@ channels:
 dependencies:
   - xarray
   - xgcm
-  - pyproj
   - cftime
-  - matplotlib
   - regionmask
   - pytest-cov
   - pytest-xdist

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -3,6 +3,8 @@ channels:
   - conda-forge
 dependencies:
   - xarray
+  - netcdf4
+  - scipy
   - xgcm
   - cftime
   - regionmask

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,19 +57,12 @@ install_requires =
     numpy
     xarray
     pandas
-    pyproj
-    matplotlib
     regionmask
     xgcm
     cftime
-    cartopy
-    cython
 setup_requires=
     setuptools
     setuptools-scm
-    wheel
-    twine
-    check-manifest
 python_requires = >=3.6
 ################ Up until here
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,7 +1,6 @@
 import itertools
 
 import numpy as np
-import pandas as pd
 import pytest
 import xarray as xr
 


### PR DESCRIPTION
I am not quite sure why we needed cartopy? But as far as I can see right now, its not a core requirement, and Ill take it out completely.
In the process I found some more useless dependencies (pandas, pyproj), which Ill remove here.