### PR TITLE
Trying to fix the setup and dependency mess

### DIFF
--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -26,9 +26,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install setuptools setuptools-scm[toml] wheel twine
-      # - name: Check current package version
-      #   run: |
-      #     python setup.py --version
+      - name: Check current package version
+        run: |
+          python setup.py --version
       - name: Build tarball and wheels
         run: |
           git clean -xdf

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -19,6 +19,8 @@ jobs:
         name: Install Python
         with:
           python-version: 3.8
+      - uses: lhotari/action-upterm@v1
+        name: Setup upterm session
       - name: Check python version
         run: |
           python --version

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -79,6 +79,12 @@ jobs:
           sleep 10
           python -m pip install --upgrade pip
           pip cache purge
+          # This is kind of stupid, but the only way I got this to work with the latest versions on testpypi
+          # If I used: python -m pip install --extra-index-url https://test.pypi.org/simple --upgrade cmip6_preprocessing
+          # It would grab an older cmip6_pp version and with `--index-url=...` I cant get the proper dependencies from pypi
+          # So I am installing the dependencies manually from pypi and the newest version from testpypi...not sure if this
+          # defeats the purpose, but I am frankly fed up with this shit!
+          python -m pip install xgcm xarray numpy pandas cftime
           python -m pip install --index-url https://test.pypi.org/simple --upgrade cmip6_preprocessing
           python -c "import cmip6_preprocessing;print(cmip6_preprocessing.__version__)"
   upload-to-pypi:

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -19,6 +19,7 @@ jobs:
         name: Install Python
         with:
           python-version: 3.8
+      - name: Check python version
         run: |
           python --version
       - name: Install dependencies

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -5,7 +5,7 @@ on:
       - published
   push:
     tags:
-      - 'v*_test'
+      - 'v*'
 
 jobs:
   build-artifacts:

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -72,14 +72,15 @@ jobs:
           password: ${{ secrets.TESTPYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
           verbose: true
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
+      # - name: Setup upterm session
+      #   uses: lhotari/action-upterm@v1
       - name: Check uploaded package
         run: |
-          sleep 20
+          sleep 10
           python -m pip install --upgrade pip
-          python -m pip install --extra-index-url https://test.pypi.org/simple --upgrade cmip6_preprocessing
-          python setup.py --version
+          pip cache purge
+          python -m pip install --index-url https://test.pypi.org/simple --upgrade cmip6_preprocessing
+          python -c "import cmip6_preprocessing;print(cmip6_preprocessing.__version__)"
   upload-to-pypi:
     needs: test-built-dist
     if: github.event_name == 'release'

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Check uploaded package
         run: |
-          sleep 3
+          sleep 20
           python -m pip install --upgrade pip
           python -m pip install --extra-index-url https://test.pypi.org/simple --upgrade cmip6_preprocessing
           python setup.py --version

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install setuptools setuptools-scm[toml]
+          python -m pip install setuptools setuptools-scm[toml] wheel twine
       # - name: Check current package version
       #   run: |
       #     python setup.py --version
@@ -33,7 +33,7 @@ jobs:
         run: |
           git clean -xdf
           git restore -SW .
-          python -m build --sdist --wheel .
+          python setup.py sdist bdist_wheel
       - name: Check built artifacts
         run: |
           python -m twine check dist/*

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -3,9 +3,9 @@ on:
   release:
     types:
       - published
-#   push:
-#     tags:
-#       - 'v*'
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   build-artifacts:

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -5,7 +5,7 @@ on:
       - published
   push:
     tags:
-      - 'v*'
+      - 'test_publish*'
 
 jobs:
   build-artifacts:

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -19,11 +19,15 @@ jobs:
         name: Install Python
         with:
           python-version: 3.8
+        run: |
+          python --version
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install setuptools setuptools-scm[toml] wheel
+          python -m pip install setuptools setuptools-scm[toml]
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
       - name: Check current package version
         run: |
           python setup.py --version

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -5,7 +5,7 @@ on:
       - published
   push:
     tags:
-      - 'test_publish*'
+      - 'v*_test'
 
 jobs:
   build-artifacts:

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install setuptools setuptools-scm wheel twine check-manifest
+          python -m pip install setuptools setuptools-scm[toml] wheel
       - name: Check current package version
         run: |
           python setup.py --version

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -19,15 +19,13 @@ jobs:
         name: Install Python
         with:
           python-version: 3.8
-      - uses: lhotari/action-upterm@v1
-        name: Setup upterm session
-      - name: Check python version
-        run: |
-          python --version
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install setuptools setuptools-scm[toml] wheel twine
+      - name: Check python version
+        run: |
+          python --version
       - name: Check current package version
         run: |
           python setup.py --version
@@ -74,12 +72,13 @@ jobs:
           password: ${{ secrets.TESTPYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
           verbose: true
-
+      - name: Setup upterm session
+        - uses: lhotari/action-upterm@v1
       - name: Check uploaded package
         run: |
           sleep 20
           python -m pip install --upgrade pip
-          python -m pip install --index-url https://test.pypi.org/simple --upgrade cmip6_preprocessing
+          python -m pip install --extra-index-url https://test.pypi.org/simple --upgrade cmip6_preprocessing
           python setup.py --version
   upload-to-pypi:
     needs: test-built-dist

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -21,16 +21,13 @@ jobs:
           python-version: 3.8
         run: |
           python --version
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install setuptools setuptools-scm[toml]
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
-      - name: Check current package version
-        run: |
-          python setup.py --version
+      # - name: Check current package version
+      #   run: |
+      #     python setup.py --version
       - name: Build tarball and wheels
         run: |
           git clean -xdf

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -73,7 +73,7 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
           verbose: true
       - name: Setup upterm session
-        - uses: lhotari/action-upterm@v1
+        uses: lhotari/action-upterm@v1
       - name: Check uploaded package
         run: |
           sleep 20

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -77,7 +77,7 @@ jobs:
         run: |
           sleep 20
           python -m pip install --upgrade pip
-          python -m pip install --extra-index-url https://test.pypi.org/simple --upgrade cmip6_preprocessing
+          python -m pip install --index-url https://test.pypi.org/simple --upgrade cmip6_preprocessing
           python setup.py --version
   upload-to-pypi:
     needs: test-built-dist

--- a/ci/environment-cloud-test.yml
+++ b/ci/environment-cloud-test.yml
@@ -2,12 +2,8 @@ name: test_env_cmip6_preprocessing
 channels:
   - conda-forge
 dependencies:
-
-  - python=3.8
   - xarray
   - xgcm
-  - cftime
-  - regionmask
   # Dependencies for the pangeo cloud data
   - intake-esm
   - gcsfs

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -7,7 +7,6 @@ dependencies:
   - scipy
   - xgcm
   - cftime
-  - regionmask
   - pytest-cov
   - pytest-xdist
   - codecov

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - scipy
   - xgcm
   - cftime
+  - regionmask
   - pytest-cov
   - pytest-xdist
   - codecov

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,12 +31,14 @@ copyright = "2021, cmip6_preprocessing maintainers"
 author = "cmip6_preprocessing maintainers"
 
 # -- Version -----------------------------------------------------------------
-# https://github.com/pypa/setuptools_scm#usage-from-sphinx
-from importlib.metadata import version  # isort:skip
-
-release = version(project)
-# for example take major/minor
-version = ".".join(release.split(".")[:2])
+# The version info for the project you're documenting, acts as replacement for
+# |version| and |release|, also used in various other places throughout the
+# built documents.
+#
+# The short X.Y version.
+version = cmip6_preprocessing.__version__.split("+")[0]
+# The full version, including alpha/beta/rc tags.
+release = cmip6_preprocessing.__version__
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,21 +24,19 @@ sys.path.insert(0, str(root))
 
 import cmip6_preprocessing  # isort:skip
 
-# The version info for the project you're documenting, acts as replacement for
-# |version| and |release|, also used in various other places throughout the
-# built documents.
-#
-# The short X.Y version.
-version = cmip6_preprocessing.__version__.split("+")[0]
-# The full version, including alpha/beta/rc tags.
-release = cmip6_preprocessing.__version__
-
-
 # -- Project information -----------------------------------------------------
 
 project = "cmip6_preprocessing"
 copyright = "2021, cmip6_preprocessing maintainers"
 author = "cmip6_preprocessing maintainers"
+
+# -- Version -----------------------------------------------------------------
+# https://github.com/pypa/setuptools_scm#usage-from-sphinx
+from importlib.metadata import version  # isort:skip
+
+release = version(project)
+# for example take major/minor
+version = ".".join(release.split(".")[:2])
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ author_email = jbusecke@princeton.edu
 [options]
 install_requires =
     numpy
+    pandas
     xarray
     xgcm
     cftime

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,6 @@ author_email = jbusecke@princeton.edu
 install_requires =
     numpy
     xarray
-    pandas
     xgcm
     cftime
 setup_requires=

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,12 +57,8 @@ install_requires =
     numpy
     xarray
     pandas
-    regionmask
     xgcm
     cftime
-    cartopy
-    proj
-    geos
 setup_requires=
     setuptools
     setuptools-scm

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(
         "write_to_template": '__version__ = "{version}"',
         "tag_regex": r"^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$",
     },
-    setup_requires=["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.0"],
+    setup_requires=["setuptools>=45", "setuptools_scm[toml]>=6.0"],
 )

--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,6 @@ setup(
         "write_to": "cmip6_preprocessing/_version.py",
         "write_to_template": '__version__ = "{version}"',
         "tag_regex": r"^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$",
-    }
+    },
+    setup_requires=["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.0"],
 )


### PR DESCRIPTION
After I implemented a more finegrained publishing CI in #129, I noticed that there are issues with the installation from pypi...I have been trying to figure out how to solve those issues, but went on a PR rampage (needing a pre-release each time) to test this. 
I hope I can trigger the release mechanism by tagging the branch locally and avoid that here.

EDIT: I think I got this now. I am still a bit unsure about the root cause, but I think that the new CI exposed some shortcomings in our pip dependencies. What followed then was a bunch of back and forth nonsense with testpypi...
The main problem is that I did not find a clear way to install only the latest `cmip6_preprocessing` version from testpypi and all dependencies from the regular index, so I am not installing the dependencies manually and then install the cmip6_pp from testpypi (this somewhat defeats the purpose, but well...).

Some notes on development: To trigger the pypi publishing CI I basically tagged each commit with a `vx.y.zrcn` tag, and pushed those, resulting in more release candidates then I ever wanted to see in my life. 


