### PR TITLE
Fix Releases breaking due to double upload to testpypi

### DIFF
--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -66,6 +66,7 @@ jobs:
           ls -ltrh
           ls -ltrh dist
       - name: Publish package to TestPyPI
+        if: github.event_name != 'release'
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           user: __token__

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -5,7 +5,7 @@ on:
       - published
   push:
     tags:
-      - 'v*'
+      - 'v*rc*' # only trigger this for dev releases (which I currently call release candidates...
 
 jobs:
   build-artifacts:
@@ -66,7 +66,6 @@ jobs:
           ls -ltrh
           ls -ltrh dist
       - name: Publish package to TestPyPI
-        if: github.event_name != 'release'
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           user: __token__


### PR DESCRIPTION
Currently a release will trigger two versions of the same workflow. This leads to an error because the testpypi package cannot be uploaded again. Here I am trying to implement a conditional that only tries to upload to testpypi if this is not an actual release