### PR TITLE
Move parallel test execution from pyproj.toml to gh actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
         run: lscpu
       - name: Run Tests
         run: |
-          pytest --cov=./ --cov-report=xml --ignore=tests/test_preprocessing_cloud.py
+          pytest -n auto --cov=./ --cov-report=xml --ignore=tests/test_preprocessing_cloud.py
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
@@ -118,7 +118,7 @@ jobs:
       run: conda list
     - name: Run Tests
       run: |
-        pytest --ignore=tests/test_preprocessing_cloud.py
+        pytest -n auto --ignore=tests/test_preprocessing_cloud.py
 
   cloud-tests:
     needs: detect-ci-trigger
@@ -168,4 +168,4 @@ jobs:
       run: |
         pwd
         echo $PYTHONPATH
-        pytest --reruns 1 --reruns-delay 5 tests/test_preprocessing_cloud.py --gl ${{ matrix.grid_label }} --ei ${{ matrix.experiment_id }} --vi ${{ matrix.variable_id }}
+        pytest -n auto --reruns 1 --reruns-delay 5 tests/test_preprocessing_cloud.py --gl ${{ matrix.grid_label }} --ei ${{ matrix.experiment_id }} --vi ${{ matrix.variable_id }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ known_third_party = ["cftime", "dask", "fsspec", "numpy", "pandas", "pkg_resourc
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = " -vv -rXfE -n auto"
+addopts = " -vv -rXfE"
 # only test the root level, otherwise it picks up the tests of the project template
 testpaths = [
     "tests",


### PR DESCRIPTION
The way this was set up, causes issues when pytest-xdist is not installed. Ill move that command to the CI only, so the user can just run the test using `pytest`.

Found by @TomNicholas