### PR TITLE
Require xarray>=0.17.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9"]
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.9.0

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -2,7 +2,7 @@ name: test_env_cmip6_preprocessing
 channels:
   - conda-forge
 dependencies:
-  - xarray
+  - xarray>=0.17.0
   - pandas<1.3 # remove this once https://github.com/pydata/xarray/issues/5581 is released
   - netcdf4
   - scipy

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -6,11 +6,14 @@ What's New
 
 v0.6.0 (unreleased)
 -------------------
+Breaking Changes
+~~~~~~~~~~~~~~~~
+- Package requires xarray>=0.17.0 and drops support for python 3.6 (:pull:`170`). By `Julius Busecke <https://github.com/jbusecke>`_
 
 Bugfixes
 ~~~~~~~~
-
 - :py:func:`~cmip6_preprocessing.drift_removal.match_and_remove_drift` does now work with chunked (dask powered) datasets (:pull:`164`).By `Julius Busecke <https://github.com/jbusecke>`_
+
 
 
 .. _whats-new.0.5.0:

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ author_email = jbusecke@princeton.edu
 install_requires =
     numpy
     pandas
-    xarray
+    xarray>=0.17.0
     xgcm
     cftime
     xarrayutils

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ install_requires =
 setup_requires=
     setuptools
     setuptools-scm
-python_requires = >=3.6
+python_requires = >=3.7
 ################ Up until here
 
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,9 +41,9 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     # Dont change this one
     License :: OSI Approved :: MIT License
 


### PR DESCRIPTION
The support for `combine_attrs=drop_conflicts` needed for some of the postprocessing logic, was only added in v0.17.0. 

We need to make it explicit that older versions are not supported anymore. Otherwise #169 will happen to more users.