### PR TITLE
Implement changes to work with xarray>=0.19.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9"]
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.9.0

--- a/ci/environment-cloud-test.yml
+++ b/ci/environment-cloud-test.yml
@@ -2,7 +2,7 @@ name: test_env_cmip6_preprocessing
 channels:
   - conda-forge
 dependencies:
-  - xarray
+  - xarray>=0.17.0
   - xgcm
   # Dependencies for the pangeo cloud data
   - intake-esm

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -8,14 +8,9 @@ dependencies:
   - scipy
   - xgcm
   - cftime
-#   - regionmask
+  - regionmask
   - xesmf
   - xarrayutils
   - pytest-cov
   - pytest-xdist
   - codecov
-  # temporary fix until regionmask 0.7.0 is on conda-forge
-  - cartopy
-  - pip
-  - pip:
-    - regionmask

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - pytest-xdist
   - codecov
   # temporary fix until regionmask 0.7.0 is on conda-forge
+  - cartopy
   - pip
   - pip:
     - regionmask

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -2,7 +2,7 @@ name: test_env_cmip6_preprocessing
 channels:
   - conda-forge
 dependencies:
-  - xarray
+  - xarray>=0.17.0
   - pandas<1.3 # remove this once https://github.com/pydata/xarray/issues/5581 is released
   - netcdf4
   - scipy

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - xgcm
   - cftime
   - regionmask
+  - cartopy
   - xesmf
   - xarrayutils
   - pytest-cov

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -8,9 +8,13 @@ dependencies:
   - scipy
   - xgcm
   - cftime
-  - regionmask
+#   - regionmask
   - xesmf
   - xarrayutils
   - pytest-cov
   - pytest-xdist
   - codecov
+  # temporary fix until regionmask 0.7.0 is on conda-forge
+  - pip
+  - pip:
+    - regionmask

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -6,9 +6,13 @@ What's New
 
 v0.6.0 (unreleased)
 -------------------
+Breaking Changes
+~~~~~~~~~~~~~~~~
+- Requires xarray>=0.17.0 and drops support for python 3.6 (:pull:`170`, :pull:`173`). By `Julius Busecke <https://github.com/jbusecke>`_
 
 Bugfixes
 ~~~~~~~~
+- Fixes incompatibility with upstream changes in xarray>=0.19.0 (:pull:`173`). By `Julius Busecke <https://github.com/jbusecke>`_
 
 - :py:func:`~cmip6_preprocessing.drift_removal.match_and_remove_drift` does now work with chunked (dask powered) datasets (:pull:`164`).By `Julius Busecke <https://github.com/jbusecke>`_
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -12,7 +12,7 @@ Breaking Changes
 
 Bugfixes
 ~~~~~~~~
-- Fixes incompatibility with upstream changes in xarray>=0.19.0 (:pull:`173`). By `Julius Busecke <https://github.com/jbusecke>`_
+- Fixes incompatibility with upstream changes in xarray>=0.19.0 (:issue:`173`, :pull:`174`). By `Julius Busecke <https://github.com/jbusecke>`_
 
 - :py:func:`~cmip6_preprocessing.drift_removal.match_and_remove_drift` does now work with chunked (dask powered) datasets (:pull:`164`).By `Julius Busecke <https://github.com/jbusecke>`_
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,9 +41,9 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     # Dont change this one
     License :: OSI Approved :: MIT License
 
@@ -56,14 +56,14 @@ author_email = jbusecke@princeton.edu
 install_requires =
     numpy
     pandas
-    xarray
+    xarray>=0.17.0
     xgcm
     cftime
     xarrayutils
 setup_requires=
     setuptools
     setuptools-scm
-python_requires = >=3.6
+python_requires = >=3.7
 ################ Up until here
 
 include_package_data = True

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -23,24 +23,26 @@ def _add_small_rand(da):
 
 def _test_data(grid_label="gn", z_axis=True):
     xt = np.arange(4) + 1
-
     yt = np.arange(5) + 1
-
     zt = np.arange(6) + 1
+
     x = xr.DataArray(xt, coords=[("x", xt)])
     y = xr.DataArray(yt, coords=[("y", yt)])
     lev = xr.DataArray(zt, coords=[("lev", zt)])
 
     # Need to add a tracer here to get the tracer dimsuffix
-    coords = [("x", x), ("y", y)]
-    data = np.random.rand(len(x), len(y))
+    coords = [("x", x.data), ("y", y.data)]
+    data = np.random.rand(len(xt), len(yt))
+    dims = ["x", "y"]
 
     if z_axis:
-        coords.append(("lev", lev))
+        coords.append(("lev", lev.data))
         data = np.random.rand(len(x), len(y), len(lev))
+        dims = ["x", "y", "lev"]
 
     tr = xr.DataArray(
         data,
+        dims=dims,
         coords=coords,
     )
 


### PR DESCRIPTION
- [ ] Closes #173

This reworks some of the test logic to accomodate changes released with the newest xarray version. 

I am also rolling the changes from #170 into this PR:
- require xarray >0.17.0
- drop support for python 3.6

Currently blocked by implementing upstream changes in https://github.com/regionmask/regionmask/pull/234