### PR TITLE
Unpin pandas

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - xarray>=0.17.0
-  - pandas<1.3 # remove this once https://github.com/pydata/xarray/issues/5581 is released
+  - pandas
   - netcdf4
   - scipy
   - xgcm


### PR DESCRIPTION
Closes #156 
The newest xarray version `0.19.0` should include a fix to this problem (see https://github.com/pydata/xarray/issues/5581).