### PR TITLE
Using cf_xarray to infer attributes

### DIFF
--- a/cmip6_preprocessing/preprocessing.py
+++ b/cmip6_preprocessing/preprocessing.py
@@ -109,6 +109,14 @@ def rename_cmip6(ds, rename_dict=None):
     # restore attributes
     ds.attrs = attrs
 
+    # use cf conventions where they can be inferred by cf_xarray
+    print('CONVERTING WITH CF CONVENION FUNCTIONS ---------')
+    print('-------------------------------')
+    print('-----------------------------')
+    ds = ds.cf.guess_coord_axis()
+    ds = ds.cf.add_canonical_attributes()
+    print('ds atrrs keys', ds.attrs.keys())
+
     return ds
 
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -66,6 +66,10 @@ def test_rename_cmip6(xname, yname, zname, missing_dim):
         assert ylen == len(ds_renamed.y)
     if not missing_dim == "z":
         assert zlen == len(ds_renamed.lev)
+    
+    # check if cf conventions were inferred
+    print('ds attrs keys from test', ds.attrs.keys())
+    assert 'history' in ds.attrs.keys()
 
 
 @pytest.mark.parametrize("xname", ["i", "x"])


### PR DESCRIPTION
## What was done
This PR adds the [`.cf.guess_coord_axis()`](https://cf-xarray.readthedocs.io/en/latest/generated/xarray.DataArray.cf.guess_coord_axis.html#xarray.DataArray.cf.guess_coord_axis) and [`.cf.add_canonical_attributes()`](https://cf-xarray.readthedocs.io/en/latest/generated/xarray.DataArray.cf.add_canonical_attributes.html#xarray.DataArray.cf.add_canonical_attributes) functions to the `preprocessing` component of the library.  This will update the dataset with additional attributes in line with CF conventions that can be inferred by the `cf_xarray` library.

## How it was done
Two lines were added to the `rename_cmip6` function:
```
    ds = ds.cf.guess_coord_axis()
    ds = ds.cf.add_canonical_attributes()
```
I put them in the `rename_cmip6` function in `preprocessing.py` because it seemed to semantically fit, but I'm certainly open to moving them if there's a better spot.

## Testing
I added an additional assertion to the `test_rename_cmip6` function in `test_preprocessing.py`.  The test is weak mostly because there isn't a lot that is guaranteed to be true after running the additional steps here.  The one check I added (because I believe it should always be true) is that `history` is present in the global attributes.  I could certainly be convinced that this in unnecessary and the test should be removed.

## WIP
This is a Work In Progress because I actually can't get the test to pass (😱).  When I use my local version of the library it works just fine so I'm not sure why the tests are working.  I thought I'd still post this, though, since the necessity of the test is questionable, before spending oodles of time debugging it.

Code I use to test the function:
```
import numpy as np
import xarray as xr

from cmip6_preprocessing.preprocessing import rename_cmip6, cmip6_renaming_dict

def create_test_ds(xname, yname, zname, xlen, ylen, zlen):
    x = np.linspace(0, 359, xlen)
    y = np.linspace(-90, 89, ylen)
    z = np.linspace(0, 5000, zlen)

    data = np.random.rand(len(x), len(y), len(z))
    ds = xr.DataArray(data, coords=[(xname, x), (yname, y), (zname, z)]).to_dataset(name="test")
    ds.attrs["source_id"] = "test_id"
    # if x and y are not lon and lat, add lon and lat to make sure there are no conflicts
    lon = ds[xname] * xr.ones_like(ds[yname])
    lat = xr.ones_like(ds[xname]) * ds[yname]
    if xname != "lon" and yname != "lat":
        ds = ds.assign_coords(lon=lon, lat=lat)
    else:
        ds = ds.assign_coords(longitude=lon, latitude=lat)
        return ds


ds = create_test_ds('i', 'j', 'lev', 10, 5, 6)
ds_renamed = rename_cmip6(ds, cmip6_renaming_dict())
# See 'history' in global attributes of `ds_renamed` but not in `ds`
```
### Seeing the test problem
This PR has a slightly annoying number of print statements, which I left in to help demonstrate how it seems that the preprocessing file is correctly using the new lines of code but (at least for me) the tests aren't.  I print the dataset keys in both the preprocessing file and the test file to show the error.
