### PR TITLE
Keep using older natural_earth version

### DIFF
--- a/tests/test_regionmask.py
+++ b/tests/test_regionmask.py
@@ -20,7 +20,7 @@ def test_merge_mask(verbose):
     ds["lon"] = ds["x"] * xr.ones_like(ds["y"])
     ds["lat"] = xr.ones_like(ds["x"]) * ds["y"]
 
-    basins = regionmask.defined_regions.natural_earth.ocean_basins_50
+    basins = regionmask.defined_regions.natural_earth_v4_1_0.ocean_basins_50
 
     mask = merged_mask(basins, ds, verbose=verbose)
 


### PR DESCRIPTION
Natural Earth recently released a new version that changed some of the marine regions (e.g. #208), leading to incompatibility issues. 

Here I am using some new regionmask features to make sure that the older version is used for testing.
This is an attempt to quickly fix the CI (which has failed for the last few weeks), but I am wondering if it would be worth in the long run, to upgrade to the latest NE version.

Related question: @mathause, is there a way to identify the NE version from a regions object? 

Something similar to this:
```python
basins = regionmask.defined_regions.natural_earth_v4_1_0.ocean_basins_50
assert basins.version == 'something'
```
?
That way I could check that in my module and give a more useful error message

TODO:
- [ ] Mention this in the docs.