### PR TITLE
Attempt to fix test checking for user warning

### DIFF
--- a/tests/test_drift_removal.py
+++ b/tests/test_drift_removal.py
@@ -530,7 +530,12 @@ def test_calculate_drift_exceptions_partial():
 
     with pytest.warns(UserWarning) as winfo:
         reg = calculate_drift(ds_control, ds, "test", compute_short_trends=True)
-    assert any(["years to calculate trend. Using 1 years only" in w.message.args[0] for w in winfo])
+    assert any(
+         [
+             "years to calculate trend. Using 1 years only" in w.message.args[0]
+             for w in winfo
+         ]
+     )
 
 
 @pytest.mark.parametrize("ref_date", ["1850", "2000-01-02"])

--- a/tests/test_drift_removal.py
+++ b/tests/test_drift_removal.py
@@ -530,7 +530,7 @@ def test_calculate_drift_exceptions_partial():
 
     with pytest.warns(UserWarning) as winfo:
         reg = calculate_drift(ds_control, ds, "test", compute_short_trends=True)
-    assert "years to calculate trend. Using 1 years only" in winfo[0].message.args[0]
+    assert any(["years to calculate trend. Using 1 years only" in w.message.args[0] for w in winfo])
 
 
 @pytest.mark.parametrize("ref_date", ["1850", "2000-01-02"])

--- a/tests/test_drift_removal.py
+++ b/tests/test_drift_removal.py
@@ -531,11 +531,11 @@ def test_calculate_drift_exceptions_partial():
     with pytest.warns(UserWarning) as winfo:
         reg = calculate_drift(ds_control, ds, "test", compute_short_trends=True)
     assert any(
-         [
-             "years to calculate trend. Using 1 years only" in w.message.args[0]
-             for w in winfo
-         ]
-     )
+        [
+            "years to calculate trend. Using 1 years only" in w.message.args[0]
+            for w in winfo
+        ]
+    )
 
 
 @pytest.mark.parametrize("ref_date", ["1850", "2000-01-02"])


### PR DESCRIPTION
Additionally to the problem with regionmask (which I started working on in #212), there seems to be an issue with a test asserting that a UserWarning is raised.

I believe the issue here is that suddenly more than one warning is raised and my old implementation did only check the first warning. 
I have now changed this to a list comparison.